### PR TITLE
allow server to run on host port

### DIFF
--- a/server.js
+++ b/server.js
@@ -61,5 +61,5 @@ const server = http.createServer((req, res) => {
     });
   }
 });
-
-server.listen(8000);
+const PORT = process.env.PORT || 8000;
+server.listen(PORT);


### PR DESCRIPTION
I changed the listening port to accept the host's port or default to 5000.  This will let us put it on Roku (hosting) and accept whatever port they designate.